### PR TITLE
feature: 카카오 소셜 로그인 커스텀 예외처리

### DIFF
--- a/src/main/java/org/backend/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/org/backend/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,36 @@
+package org.backend.auth.exception;
+
+import java.time.LocalDateTime;
+import org.backend.global.response.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.context.request.WebRequest;
+
+@ControllerAdvice
+public class AuthExceptionHandler {
+
+    @ExceptionHandler(KakaoTokenRetrievalFailedException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoTokenRetrievalFailedException(KakaoTokenRetrievalFailedException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().getHttpStatus(),
+                exception.getResponseCode().name(),
+                exception.getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+
+    @ExceptionHandler(KakaoUserRetrievalFailedException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoUserRetrievalFailedExcetpion(KakaoUserRetrievalFailedException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().getHttpStatus(),
+                exception.getResponseCode().name(),
+                exception.getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
+}

--- a/src/main/java/org/backend/auth/exception/KakaoTokenRetrievalFailedException.java
+++ b/src/main/java/org/backend/auth/exception/KakaoTokenRetrievalFailedException.java
@@ -1,0 +1,11 @@
+package org.backend.auth.exception;
+
+import org.backend.global.exception.BaseException;
+import org.backend.global.response.ResponseCode;
+
+public class KakaoTokenRetrievalFailedException extends BaseException {
+
+    public KakaoTokenRetrievalFailedException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/org/backend/auth/exception/KakaoUserRetrievalFailedException.java
+++ b/src/main/java/org/backend/auth/exception/KakaoUserRetrievalFailedException.java
@@ -1,0 +1,11 @@
+package org.backend.auth.exception;
+
+import org.backend.global.exception.BaseException;
+import org.backend.global.response.ResponseCode;
+
+public class KakaoUserRetrievalFailedException extends BaseException {
+
+    public KakaoUserRetrievalFailedException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/org/backend/global/response/ResponseCode.java
+++ b/src/main/java/org/backend/global/response/ResponseCode.java
@@ -4,12 +4,12 @@ import org.springframework.http.HttpStatus;
 
 public enum ResponseCode {
 
-    /*
+    /**
     Login
      */
     LOGIN_SUCCES(HttpStatus.OK, "로그인에 성공하셨습니다."),
 
-    /*
+    /**
     Basic
      */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
@@ -17,7 +17,7 @@ public enum ResponseCode {
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메소드입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생하였습니다."),
 
-    /*
+    /**
     Member
      */
     MEMBER_CREATED(HttpStatus.CREATED, "회원가입 성공"),
@@ -30,7 +30,7 @@ public enum ResponseCode {
 
     MEMBER_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "회원 정보 삭제 성공"),
 
-    /*
+    /**
     TravelCourse
      */
     COURSE_CREATED(HttpStatus.CREATED, "여행코스 생성 성공"),
@@ -43,7 +43,7 @@ public enum ResponseCode {
 
     COURSE_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "여행코스 삭제 성공"),
 
-    /*
+    /**
     Location
      */
     LOCATION_CREATED(HttpStatus.CREATED, "위치 생성 성공"),
@@ -53,7 +53,14 @@ public enum ResponseCode {
     LOCATION_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 존재하는 위치 정보입니다."),
 
     LOCATION_READ_SUCCESS(HttpStatus.OK, "위치 조회 성공"),
-    LOCATION_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "위치 삭제 성공");
+    LOCATION_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "위치 삭제 성공"),
+
+    /**
+     * Kakao
+     */
+    KAKAO_TOKEN_RETRIEVAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR , "카카오 토큰 가져오기 실패"),
+    KAKAO_USER_RETRIEVAL_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "카카오 유저 정보 가져오기 실패");
+
 
     private HttpStatus status;
     private String message;

--- a/src/test/java/org/backend/auth/KakaoLoginTest.java
+++ b/src/test/java/org/backend/auth/KakaoLoginTest.java
@@ -1,0 +1,8 @@
+package org.backend.auth;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class KakaoLoginTest {
+
+}


### PR DESCRIPTION
## 개요

- 카카오 소셜 로그인 예외 처리가 존재하지 않음.

### PR 타입

- 기능 추가

### 변경 사항

- 카카오 소셜 로그인 커스텀 예외 처리
- 카카오 액세스 토큰 요청할  때 예외 발생 시 커스텀 예외 처리 진행
- 카카오 유저 정보 요청할 때  예외 발생 시 커스텀 예외 처리 진행

### 테스트 결과

- [X] 카카오 액세스 토큰 요청할 때 커스텀 예외 처리 진행
- [ ] 카카오 유저 정보 요청할 때  예외 발생 시 커스텀 예외 처리 진행