### PR TITLE
refactor: 시간 정보 적용 안되는 부분 수정

### DIFF
--- a/src/main/java/org/backend/common/BaseTimeEntity.java
+++ b/src/main/java/org/backend/common/BaseTimeEntity.java
@@ -1,5 +1,6 @@
 package org.backend.common;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -12,6 +13,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 public class BaseTimeEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdDate;
 
     @LastModifiedDate

--- a/src/main/java/org/backend/global/config/JpaConfig.java
+++ b/src/main/java/org/backend/global/config/JpaConfig.java
@@ -1,9 +1,11 @@
 package org.backend.global.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
-@EnableJpaRepositories(basePackages = "org.backend")
 @Configuration
+@EnableJpaRepositories(basePackages = "org.backend")
+@EnableJpaAuditing
 public class JpaConfig {
 }


### PR DESCRIPTION
## 개요

- 사용자 정보 저장 시 BaseTimeEntity 적용 안됨

### PR 타입

- 리팩터링

### 변경 사항

- @EnableJpaAuditing 어노테이션 추가

### 테스트 결과

- [X] 사용자 정보 저장 시 시간 적용