### PR TITLE
feat: refreshToekn 재발급 시 사용자 정보에 반영

### DIFF
--- a/src/main/java/org/backend/auth/filter/JwtAuthFilter.java
+++ b/src/main/java/org/backend/auth/filter/JwtAuthFilter.java
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.backend.auth.application.AuthService;
 import org.backend.auth.jwt.JwtUtils;
+import org.backend.auth.jwt.Token;
 import org.backend.member.application.MemberService;
 import org.backend.member.domain.Member;
 import org.springframework.security.core.Authentication;
@@ -44,8 +45,9 @@ public class JwtAuthFilter extends GenericFilterBean {
         else if(refreshToken != null) {
             Member member = memberService.findByRefreshToken(refreshToken);
             if(member != null) {
-                jwtUtil.reIssueToken((HttpServletResponse) response, member.getEmail());
-                Authentication auth = authService.getAuthentication(member.getEmail(), member.getRole().getKey());
+                Token token = jwtUtil.reIssueToken((HttpServletResponse) response, member.getEmail());
+                Member registeredMember = memberService.register(member, token);
+                Authentication auth = authService.getAuthentication(registeredMember.getEmail(), registeredMember.getRole().getKey());
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
         }

--- a/src/main/java/org/backend/auth/jwt/JwtUtils.java
+++ b/src/main/java/org/backend/auth/jwt/JwtUtils.java
@@ -129,10 +129,11 @@ public class JwtUtils {
                 .map(refreshToken -> refreshToken.replace(BEARER, ""));
     }
 
-    public void reIssueToken(HttpServletResponse response, String email) {
+    public Token reIssueToken(HttpServletResponse response, String email) {
         Token token = createToken(email);
         response.setStatus(HttpServletResponse.SC_OK);
         response.setHeader(AUTHORIZATION, BEARER + token.getAccessToken());
         response.setHeader(AUTHORIZATION_REFRESH_TOKEN, BEARER + token.getRefreshToken());
+        return token;
     }
 }


### PR DESCRIPTION
## 개요

- refreshToken 재발급 시 사용자 정보에 미반영

### PR 타입

- 리팩터링

### 변경 사항

- JwtAuthFilter에 재발급 토큰 저장 로직 구현

### 테스트 결과

- [X] 토큰 재발급 시 정보 저장