### PR TITLE
feat: 여행코스 서비스 및 컨트롤러 테스트

### DIFF
--- a/src/main/java/org/backend/member/domain/Member.java
+++ b/src/main/java/org/backend/member/domain/Member.java
@@ -29,6 +29,14 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private Role role;
 
+    public Member(Long id, String email, String name, String refreshToken, Role role) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.refreshToken = refreshToken;
+        this.role = role;
+    }
+
     public Member(String email, String name, String refreshToken, Role role) {
         this.email = email;
         this.name = name;

--- a/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
+++ b/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
@@ -20,27 +20,24 @@ public class TravelCourseService {
 
     public TravelCourseResponse save(TravelCourseRequest request) {
         TravelCourse travelCourse = travelCourseRepository.save(request.toEntity());
-
-        return new TravelCourseResponse(
-                travelCourse.getId(),
-                travelCourse.getSchedule(),
-                travelCourse.getConcept(),
-                travelCourse.getAccommodation(),
-                travelCourse.isShared()
-        );
+        return TravelCourseResponse.toResponseDto(travelCourse);
     }
 
-    public TravelCourse findById(Long id) {
-        return travelCourseRepository.findById(id)
+    public TravelCourseResponse findById(Long id) {
+        TravelCourse travelCourse = travelCourseRepository.findById(id)
                 .orElseThrow(() -> new TravelCouresNotFoundException(ResponseCode.COURSE_NOT_FOUND));
+        return TravelCourseResponse.toResponseDto(travelCourse);
     }
 
-    public List<TravelCourse> findByMemberId(Long id) {
+    public List<TravelCourseResponse> findByMemberId(Long id) {
         return travelCourseRepository.findByMemberId(id)
-                .orElseThrow(() -> new TravelCouresNotFoundException(ResponseCode.COURSE_NOT_FOUND_MEMBER));
+                .orElseThrow(() -> new TravelCouresNotFoundException(ResponseCode.COURSE_NOT_FOUND_MEMBER))
+                .stream().map(TravelCourseResponse::toResponseDto).toList();
     }
 
     public void deleteById(Long id) {
+        travelCourseRepository.findById(id)
+                .orElseThrow(() -> new TravelCouresNotFoundException(ResponseCode.COURSE_NOT_FOUND));
         travelCourseRepository.deleteById(id);
     }
 }

--- a/src/main/java/org/backend/travelcourse/controller/TravelCourseController.java
+++ b/src/main/java/org/backend/travelcourse/controller/TravelCourseController.java
@@ -2,15 +2,13 @@ package org.backend.travelcourse.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.net.URI;
 import java.util.List;
 import org.backend.global.response.ApiResponse;
 import org.backend.global.response.ResponseCode;
 import org.backend.travelcourse.dto.TravelCourseRequest;
 import org.backend.travelcourse.dto.TravelCourseResponse;
 import org.backend.travelcourse.application.TravelCourseService;
-import org.backend.travelcourse.domain.TravelCourse;
-import org.springframework.http.ResponseEntity;
+import org.backend.travelcourse.exception.TravelCourseBadRequestException;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,7 +34,7 @@ public class TravelCourseController {
         if (travelCourseRequest.schedule() == null
         || travelCourseRequest.concept() == null
         || travelCourseRequest.accommodation() == null) {
-            return ApiResponse.fail(ResponseCode.BAD_REQUEST);
+            throw new TravelCourseBadRequestException(ResponseCode.BAD_REQUEST);
         }
         TravelCourseResponse travelCourseResponse = travelCourseService.save(travelCourseRequest);
         return ApiResponse.success(ResponseCode.COURSE_CREATED, travelCourseResponse);
@@ -44,13 +42,13 @@ public class TravelCourseController {
 
     @GetMapping("/travel-courses/{id}")
     @Operation(summary = "단일 여행코스 정보 조회", description = "여행코스 고유 ID 값을 이용해 여행코스를 조회하기 위해 사용하는 API")
-    public ApiResponse<TravelCourse> myTravelCourse(@PathVariable Long id) {
+    public ApiResponse<TravelCourseResponse> myTravelCourse(@PathVariable Long id) {
         return ApiResponse.success(ResponseCode.COURSE_READ_SUCCESS, travelCourseService.findById(id));
     }
 
     @GetMapping("/travel-courses/members/{id}")
     @Operation(summary = "사용자의 여행코스 목록 조회", description = "사용자의 고유 ID를 이용해 저장한 여행코스 목록을 조회하기 위해 사용하는 API")
-    public ApiResponse<List<TravelCourse>> myTravelCourseList(@PathVariable Long id) {
+    public ApiResponse<List<TravelCourseResponse>> myTravelCourseList(@PathVariable Long id) {
         return ApiResponse.success(ResponseCode.COURSE_MEMBER_READ_SUCCESS, travelCourseService.findByMemberId(id));
     }
 

--- a/src/main/java/org/backend/travelcourse/domain/Accommodation.java
+++ b/src/main/java/org/backend/travelcourse/domain/Accommodation.java
@@ -1,4 +1,4 @@
-package org.backend.courseinfo;
+package org.backend.travelcourse.domain;
 
 public enum Accommodation {
 

--- a/src/main/java/org/backend/travelcourse/domain/Concept.java
+++ b/src/main/java/org/backend/travelcourse/domain/Concept.java
@@ -1,4 +1,4 @@
-package org.backend.courseinfo;
+package org.backend.travelcourse.domain;
 
 public enum Concept {
 

--- a/src/main/java/org/backend/travelcourse/domain/Schedule.java
+++ b/src/main/java/org/backend/travelcourse/domain/Schedule.java
@@ -1,4 +1,4 @@
-package org.backend.courseinfo;
+package org.backend.travelcourse.domain;
 
 public enum Schedule {
 

--- a/src/main/java/org/backend/travelcourse/domain/TravelCourse.java
+++ b/src/main/java/org/backend/travelcourse/domain/TravelCourse.java
@@ -7,9 +7,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import org.backend.common.BaseTimeEntity;
-import org.backend.courseinfo.Accommodation;
-import org.backend.courseinfo.Concept;
-import org.backend.courseinfo.Schedule;
 import org.backend.member.domain.Member;
 
 @Entity
@@ -33,6 +30,20 @@ public class TravelCourse extends BaseTimeEntity {
 
     @ManyToOne
     private Member member;
+
+    public TravelCourse(Long id,
+                        Schedule schedule,
+                        Concept concept,
+                        Accommodation accommodation,
+                        boolean isShared,
+                        Member member) {
+        this.id = id;
+        this.schedule = schedule;
+        this.concept = concept;
+        this.accommodation = accommodation;
+        this.isShared = isShared;
+        this.member = member;
+    }
 
     public TravelCourse(Schedule schedule,
                         Concept concept,

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourseRequest.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourseRequest.java
@@ -1,8 +1,8 @@
 package org.backend.travelcourse.dto;
 
-import org.backend.courseinfo.Accommodation;
-import org.backend.courseinfo.Concept;
-import org.backend.courseinfo.Schedule;
+import org.backend.travelcourse.domain.Accommodation;
+import org.backend.travelcourse.domain.Concept;
+import org.backend.travelcourse.domain.Schedule;
 import org.backend.travelcourse.domain.TravelCourse;
 
 public record TravelCourseRequest(

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourseResponse.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourseResponse.java
@@ -1,8 +1,9 @@
 package org.backend.travelcourse.dto;
 
-import org.backend.courseinfo.Accommodation;
-import org.backend.courseinfo.Concept;
-import org.backend.courseinfo.Schedule;
+import org.backend.travelcourse.domain.Accommodation;
+import org.backend.travelcourse.domain.Concept;
+import org.backend.travelcourse.domain.Schedule;
+import org.backend.travelcourse.domain.TravelCourse;
 
 public record TravelCourseResponse(
         Long id,
@@ -11,4 +12,13 @@ public record TravelCourseResponse(
         Accommodation accommodation,
         boolean isShared
 ) {
+    public static TravelCourseResponse toResponseDto(TravelCourse travelCourse) {
+        return new TravelCourseResponse(
+                travelCourse.getId(),
+                travelCourse.getSchedule(),
+                travelCourse.getConcept(),
+                travelCourse.getAccommodation(),
+                travelCourse.isShared()
+        );
+    }
 }

--- a/src/main/java/org/backend/travelcourse/exception/TravelCourseBadRequestException.java
+++ b/src/main/java/org/backend/travelcourse/exception/TravelCourseBadRequestException.java
@@ -1,0 +1,11 @@
+package org.backend.travelcourse.exception;
+
+import org.backend.global.exception.BaseException;
+import org.backend.global.response.ResponseCode;
+
+public class TravelCourseBadRequestException extends BaseException {
+
+    public TravelCourseBadRequestException(ResponseCode response) {
+        super(response);
+    }
+}

--- a/src/main/java/org/backend/travelcourse/exception/TravelCourseExceptionHandler.java
+++ b/src/main/java/org/backend/travelcourse/exception/TravelCourseExceptionHandler.java
@@ -21,4 +21,16 @@ public class TravelCourseExceptionHandler {
         );
         return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
     }
+
+    @ExceptionHandler(TravelCourseBadRequestException.class)
+    public ResponseEntity<ErrorResponse> handleTravelCourseBadRequestException(TravelCourseBadRequestException exception, WebRequest request) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                LocalDateTime.now(),
+                exception.getResponseCode().getHttpStatus(),
+                exception.getResponseCode().name(),
+                exception.getMessage(),
+                request.getDescription(false)
+        );
+        return new ResponseEntity<>(errorResponse, exception.getResponseCode().getHttpStatus());
+    }
 }

--- a/src/test/java/org/backend/place/application/PlaceServiceTest.java
+++ b/src/test/java/org/backend/place/application/PlaceServiceTest.java
@@ -1,13 +1,8 @@
 package org.backend.place.application;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.util.Optional;
 import org.backend.place.domain.Place;
@@ -17,6 +12,7 @@ import org.backend.place.dto.PlaceRequest;
 import org.backend.place.dto.PlaceResponse;
 import org.backend.place.exception.PlaceAlreadyExistException;
 import org.backend.place.exception.PlaceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,11 +31,12 @@ public class PlaceServiceTest {
     @InjectMocks
     private PlaceService placeService;
 
-    @Test
-    @DisplayName("장소 정보 저장을 테스트합니다.")
-    void testSavePlace() {
-        // given
-        PlaceRequest request = new PlaceRequest(
+    private PlaceRequest placeRequest;
+    private Place place;
+
+    @BeforeEach
+    void setUp() {
+        placeRequest = new PlaceRequest(
                 "10001",
                 "Sample Place 1",
                 PlaceType.ACCOMMODATION,
@@ -48,31 +45,33 @@ public class PlaceServiceTest {
                 null,
                 null,
                 null);
-        Place placeEntity = request.toEntity();
 
+        place = new Place(1L,
+                "10001",
+                "Sample Place 1",
+                PlaceType.ACCOMMODATION,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    @Test
+    @DisplayName("장소 정보 저장을 테스트합니다.")
+    void testSavePlace() {
         // when
-        doReturn(placeEntity).when(placeRepository).save(any(Place.class));
-        PlaceResponse response = placeService.save(request);
+        doReturn(place).when(placeRepository).save(any(Place.class));
+        PlaceResponse response = placeService.save(placeRequest);
 
         // then
         assertNotNull(response);
-        assertEquals(response.contentid(), request.contentid());
+        assertEquals(response.contentid(), placeRequest.contentid());
     }
 
     @Test
     @DisplayName("장소 정보 조회를 테스트합니다.")
     void testGetPlace() {
-        // given
-        Place place = new Place(1L,
-                "10001",
-                "Sample Place 1",
-                PlaceType.ACCOMMODATION,
-                null,
-                null,
-                null,
-                null,
-                null);
-
         // when
         when(placeRepository.findById(1L)).thenReturn(Optional.of(place));
         PlaceResponse response = placeService.findById(1L);
@@ -85,17 +84,6 @@ public class PlaceServiceTest {
     @Test
     @DisplayName("장소 정보 조회 시 찾을 수 없는 예외 발생 테스트 입니다.")
     void testFindByIdException() {
-        // given
-        Place place = new Place(1L,
-                "10001",
-                "Sample Place 1",
-                PlaceType.ACCOMMODATION,
-                null,
-                null,
-                null,
-                null,
-                null);
-
         // when
         when(placeRepository.findById(1L)).thenThrow(PlaceNotFoundException.class);
 
@@ -107,20 +95,8 @@ public class PlaceServiceTest {
     @Test
     @DisplayName("장소 정보 조회 시 장소 정보가 이미 존재하는지 검증하는 테스트를 진행합니다.")
     void testValidateLocationPlace() {
-        // given
-        PlaceRequest request = new PlaceRequest(
-                "10001",
-                "Sample Place 1",
-                PlaceType.ACCOMMODATION,
-                null,
-                null,
-                null,
-                null,
-                null);
-        Place place = request.toEntity();
-
         // when
-        placeService.validatePlace(request);
+        placeService.validatePlace(placeRequest);
 
         // then
         verify(placeRepository).findByLatitudeAndLongitude(place.getMapx(), place.getMapy());
@@ -129,60 +105,34 @@ public class PlaceServiceTest {
     @Test
     @DisplayName("장소 정보를 삭제를 테스트합니다.")
     void testDeletePlace() {
-        // given
-        Long placeId = 1L;
-        Place place = new Place(1L,
-                "10001",
-                "Sample Place 1",
-                PlaceType.ACCOMMODATION,
-                null,
-                null,
-                null,
-                null,
-                null);
-
         // when
-        when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
-        placeService.deleteById(placeId);
+        when(placeRepository.findById(1L)).thenReturn(Optional.of(place));
+        placeService.deleteById(1L);
 
         // then
-        verify(placeRepository).deleteById(placeId);
+        verify(placeRepository).deleteById(1L);
     }
 
     @Test
     @DisplayName("장소 정보 삭제 시 장소 정보가 존재하지 않는 예외 처리 테스트를 진행합니다.")
     void testDeletePlaceException() {
-        // given
-        Long placeId = 1L;
-
         // when
-        when(placeRepository.findById(placeId)).thenReturn(Optional.empty());
+        when(placeRepository.findById(1L)).thenReturn(Optional.empty());
 
         // then
-        assertThrows(PlaceNotFoundException.class, () -> placeService.deleteById(placeId));
-        verify(placeRepository, never()).deleteById(placeId);
+        assertThrows(PlaceNotFoundException.class, () -> placeService.deleteById(1L));
+        verify(placeRepository, never()).deleteById(1L);
     }
 
     @Test
     @DisplayName("장소 정보가 이미 존재하는 예외 발생 테스트 입니다.")
     void testValidateLocationException() {
-        PlaceRequest request = new PlaceRequest(
-                "10001",
-                "Sample Place 1",
-                PlaceType.ACCOMMODATION,
-                null,
-                null,
-                null,
-                null,
-                null);
-        Place place = request.toEntity();
-
         // when
         when(placeRepository.findByLatitudeAndLongitude(place.getMapx(), place.getMapy())).thenThrow(
                 PlaceAlreadyExistException.class);
 
         // then
         assertThrows(PlaceAlreadyExistException.class,
-                () -> placeService.validatePlace(request));
+                () -> placeService.validatePlace(placeRequest));
     }
 }

--- a/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
+++ b/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
@@ -1,0 +1,173 @@
+package org.backend.travelcourse.application;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.backend.member.domain.Member;
+import org.backend.member.domain.Role;
+import org.backend.travelcourse.domain.Accommodation;
+import org.backend.travelcourse.domain.Concept;
+import org.backend.travelcourse.domain.Schedule;
+import org.backend.travelcourse.domain.TravelCourse;
+import org.backend.travelcourse.domain.TravelCourseRepository;
+import org.backend.travelcourse.dto.TravelCourseRequest;
+import org.backend.travelcourse.dto.TravelCourseResponse;
+import org.backend.travelcourse.exception.TravelCouresNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("local")
+public class TravelCourseServiceTest {
+
+    @Mock
+    private TravelCourseRepository travelCourseRepository;
+
+    @InjectMocks
+    private TravelCourseService travelCourseService;
+
+    private TravelCourse travelCourse;
+    private TravelCourseRequest travelCourseRequest;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        travelCourseRequest = new TravelCourseRequest(
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false
+        );
+
+        travelCourse = new TravelCourse(
+                1L,
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false,
+                null
+        );
+
+        member = new Member(
+                1L,
+                "test@test.com",
+                null,
+                null,
+                Role.USER
+        );
+    }
+
+    @Test
+    @DisplayName("여행 코스 저장을 테스트합니다.")
+    void testSave() {
+        // when
+        when(travelCourseRepository.save(any(TravelCourse.class))).thenReturn(travelCourse);
+        TravelCourseResponse response = travelCourseService.save(travelCourseRequest);
+
+        // then
+        assertNotNull(response);
+        assertEquals(response.concept(), Concept.ACTIVITY_LEISURE);
+    }
+
+    @Test
+    @DisplayName("고유 아이디 값으로 여행코스 조회를 테스트합니다.")
+    void testFindById() {
+        // when
+        when(travelCourseRepository.findById(1L)).thenReturn(Optional.of(travelCourse));
+        TravelCourseResponse response = travelCourseService.findById(1L);
+
+        // then
+        assertNotNull(response);
+        assertEquals(response.accommodation(), Accommodation.CONDOMINIUM);
+    }
+
+    @Test
+    @DisplayName("고유 아이디로 여행코스 정보 조회 시 찾을 수 없는 예외 발생 테스트 입니다.")
+    void testTravelCourseNotFundException() {
+        // when
+        when(travelCourseRepository.findById(1L)).thenThrow(TravelCouresNotFoundException.class);
+
+        // then
+        assertThrows(TravelCouresNotFoundException.class,
+                () -> travelCourseService.findById(1L));
+    }
+
+    @Test
+    @DisplayName("회원의 고유 값으로 여행코스 리스트 조회를 테스트합니다.")
+    void testFindByMemberId() {
+        // given
+        TravelCourse travelCourse1 = new TravelCourse(
+                1L,
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false,
+                member
+        );
+
+        TravelCourse travelCourse2 = new TravelCourse(
+                2L,
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false,
+                member
+        );
+
+        List<TravelCourse> courseList = List.of(travelCourse1, travelCourse2);
+
+        // when
+        when(travelCourseRepository.findByMemberId(member.getId())).thenReturn(Optional.of(courseList));
+        List<TravelCourseResponse> responses = travelCourseService.findByMemberId(member.getId());
+
+        // then
+        assertNotNull(responses);
+        assertEquals(responses.get(0).accommodation(), Accommodation.CONDOMINIUM);
+        assertEquals(responses.get(1).accommodation(), Accommodation.CONDOMINIUM);
+    }
+
+    @Test
+    @DisplayName("회원 정보로 여행코스 조회 시 찾을 수 없는 예외 처리 발생 테스트입니다.")
+    void testFindByMemberIdException() {
+        // when
+        when(travelCourseRepository.findByMemberId(member.getId())).thenThrow(TravelCouresNotFoundException.class);
+
+        // then
+        assertThrows(TravelCouresNotFoundException.class,
+                () -> travelCourseService.findByMemberId(member.getId()));
+    }
+
+    @Test
+    @DisplayName("고유 아이디로 여행코스 삭제를 테스트합니다.")
+    void testDeleteById() {
+        // when
+        when(travelCourseRepository.findById(1L)).thenReturn(Optional.of(travelCourse));
+        travelCourseService.deleteById(1L);
+
+        // then
+        verify(travelCourseRepository).deleteById(1L);
+    }
+
+    @Test
+    @DisplayName("고유 아이디로 여행코스 삭제 시 예외 발생 테스트합니다.")
+    void testDeleteByIdException() {
+        // when
+        when(travelCourseRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(TravelCouresNotFoundException.class,
+                () -> travelCourseService.deleteById(1L));
+    }
+}

--- a/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
+++ b/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
@@ -1,0 +1,195 @@
+package org.backend.travelcourse.controller;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.backend.member.domain.Member;
+import org.backend.member.domain.Role;
+import org.backend.travelcourse.application.TravelCourseService;
+import org.backend.travelcourse.domain.Accommodation;
+import org.backend.travelcourse.domain.Concept;
+import org.backend.travelcourse.domain.Schedule;
+import org.backend.travelcourse.domain.TravelCourse;
+import org.backend.travelcourse.dto.TravelCourseRequest;
+import org.backend.travelcourse.dto.TravelCourseResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(TravelCourseController.class)
+@ActiveProfiles("local")
+public class TravelCourseControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private TravelCourseService travelCourseService;
+
+    @Autowired
+    private ObjectMapper mapper;
+
+    private TravelCourseRequest validRequest;
+    private TravelCourseRequest invalidRequest;
+    private TravelCourse travelCourse;
+    private Member member;
+    private Long travelCourseId;
+    private Long memberId;
+
+    @BeforeEach
+    void setUp() {
+        validRequest = new TravelCourseRequest(
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false
+        );
+
+        invalidRequest = new TravelCourseRequest(
+                null,
+                null,
+                null,
+                false
+        );
+
+        travelCourse = new TravelCourse(
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false
+        );
+
+        member = new Member(
+                1L,
+                "test@test.com",
+                null,
+                null,
+                Role.USER
+        );
+
+        travelCourseId = 1L;
+        memberId = 1L;
+    }
+
+    @Test
+    @DisplayName("여행코스 생성 API를 테스트합니다.")
+    @WithMockUser(username = "test", roles = "USER")
+    void testCreate() throws Exception {
+        // when
+        when(travelCourseService.save(validRequest)).thenReturn(TravelCourseResponse.toResponseDto(travelCourse));
+
+        // then
+        mockMvc.perform(post("/api/travel-courses")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(validRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body.data.schedule").value("ONE_NIGHTS"));
+    }
+
+    @Test
+    @DisplayName("여행코스 생성 시 멤버 권한 예외 발생 테스트를 진행합니다.")
+    @WithMockUser(username = "test", roles = "GUEST")
+    void testCreateAuthorizationException() throws Exception {
+        // when
+        when(travelCourseService.save(validRequest)).thenThrow(AccessDeniedException.class);
+
+        // then
+        mockMvc.perform(post("/api/travel-courses")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(validRequest)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("여행코스 생성 시 잘못된 요청 예외 발생을 테스트합니다.")
+    @WithMockUser(username = "test User", roles = "USER")
+    void testCreateBacRequestException() throws Exception {
+        // then
+        mockMvc.perform(post("/api/travel-courses")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json")
+                        .content(mapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("단일 여행코스 정보 조회 API를 테스트합니다.")
+    @WithMockUser(username = "test User", roles = "USER")
+    void testMyTravelCourse() throws Exception {
+        // when
+        when(travelCourseService.findById(travelCourseId)).thenReturn(TravelCourseResponse.toResponseDto(travelCourse));
+
+        // then
+        mockMvc.perform(get("/api/travel-courses/{id}", travelCourseId)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body.data.schedule").value("ONE_NIGHTS"));
+    }
+
+    @Test
+    @DisplayName("사용자의 여행코스 목록 조회")
+    @WithMockUser(username = "test User", roles = "USER")
+    void testMyTravelCourseList() throws Exception {
+        // given
+        TravelCourse travelCourse1 = new TravelCourse(
+                1L,
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false,
+                member
+        );
+
+        TravelCourse travelCourse2 = new TravelCourse(
+                2L,
+                Schedule.ONE_NIGHTS,
+                Concept.ACTIVITY_LEISURE,
+                Accommodation.CONDOMINIUM,
+                false,
+                member
+        );
+
+        List<TravelCourseResponse> courseList = List.of(TravelCourseResponse.toResponseDto(travelCourse1), TravelCourseResponse.toResponseDto(travelCourse2));
+
+        // when
+        when(travelCourseService.findByMemberId(memberId)).thenReturn(courseList);
+
+        // then
+        mockMvc.perform(get("/api/travel-courses/members/{id}", memberId)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body.data[0].schedule").value("ONE_NIGHTS"));
+    }
+
+    @Test
+    @DisplayName("여행코스 삭제 API를 테스트합니다.")
+    @WithMockUser(username = "testUser", roles = "USER")
+    void testDelete() throws Exception {
+        // when
+        doNothing().when(travelCourseService).deleteById(travelCourseId);
+
+        // then
+        mockMvc.perform(delete("/api/travel-courses/{id}", travelCourseId)
+                        .with(SecurityMockMvcRequestPostProcessors.csrf()))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
### 개요

- 기존 Swagger로 테스트하던 과정을 여행코스 서비스 및 컨트롤러 테스트 코드 작성으로 변경

### 반영 브랜치

- `feature/travelcourse-test` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- TravelCourseServiceTest 테스트 작성
- TravelCourseControllerTest 테스트 작성

### 테스트 결과

- [X] TravelCourseServiceTest 통과
- [X] TravelCourseControllerTest 통과