### PR TITLE
feat: 여행코스에 유튜버의 동영상 링크 컬럼 추가

### DIFF
--- a/src/main/java/org/backend/travelcourse/domain/TravelCourse.java
+++ b/src/main/java/org/backend/travelcourse/domain/TravelCourse.java
@@ -36,17 +36,32 @@ public class TravelCourse extends BaseTimeEntity {
     @Enumerated(value = EnumType.STRING)
     private CreatorType creatorType;
 
+    @Column(nullable = true, name = "youtube_url")
+    private String youtubeURL;
+
     @ManyToOne
     private Member member;
 
     public TravelCourse(Long travelCourseId, String courseName, boolean isShared, int days, String creatorName,
-                        CreatorType creatorType, Member member) {
+                        CreatorType creatorType, String youtubeURL, Member member) {
         this.travelCourseId = travelCourseId;
         this.courseName = courseName;
         this.isShared = isShared;
         this.days = days;
         this.creatorName = creatorName;
         this.creatorType = creatorType;
+        this.youtubeURL = youtubeURL;
+        this.member = member;
+    }
+
+    public TravelCourse(String courseName, boolean isShared, int days, String creatorName, CreatorType creatorType,
+                        String youtubeURL, Member member) {
+        this.courseName = courseName;
+        this.isShared = isShared;
+        this.days = days;
+        this.creatorName = creatorName;
+        this.creatorType = creatorType;
+        this.youtubeURL = youtubeURL;
         this.member = member;
     }
 
@@ -94,6 +109,10 @@ public class TravelCourse extends BaseTimeEntity {
 
     public void setMember(Member member) {
         this.member = member;
+    }
+
+    public String getYoutubeURL() {
+        return youtubeURL;
     }
 
     public Long getTravelCourseId() {

--- a/src/main/java/org/backend/travelcoursedetail/domain/TravelCourseDetail.java
+++ b/src/main/java/org/backend/travelcoursedetail/domain/TravelCourseDetail.java
@@ -9,12 +9,13 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import org.backend.common.BaseTimeEntity;
 import org.backend.place.domain.Place;
 import org.backend.travelcourse.domain.TravelCourse;
 
 @Entity
 @Table(name = "travel_course_detail")
-public class TravelCourseDetail {
+public class TravelCourseDetail extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### 개요

- 유튜버 여행코스에 해당 동영상 링크를 추가

### 반영 브랜치

- `refactor/travelcourse-domain-2` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- 여행코스 테이블에 유튜브 동영상 링크 컬럼을 추가

### 테스트 결과

- [X] DB 적용 확인 