### PR TITLE
refactor: 프론트엔드와의 통신을 위해 api 허용

### DIFF
--- a/src/main/java/org/backend/global/config/WebConfig.java
+++ b/src/main/java/org/backend/global/config/WebConfig.java
@@ -9,7 +9,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
 
     @Value("${spring.cors.allowed-origins}")
-    private String LOCALHOST_SPRING;
+    private String ALLOWED_ORIGINS;
 
     @Value("${spring.cors.allowed-methods}")
     private String ALLOWED_METHODS;
@@ -29,8 +29,8 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(LOCALHOST_SPRING)
-                .allowedMethods(ALLOWED_METHODS)
+                .allowedOrigins(ALLOWED_ORIGINS.split(","))
+                .allowedMethods(ALLOWED_METHODS.split(","))
                 .allowedHeaders(ALLOWED_HEADERS_KEY_1, ALLOWED_HEADERS_KEY_2)
                 .exposedHeaders(EXPOSED_HEADERS)
                 .allowCredentials(ALLOW_CREDENTIALS)


### PR DESCRIPTION
### 개요

- 프론트엔드 cors 허용 요구

### 반영 브랜치

- `refactor/webconfig-1` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- 프론트엔드 CORS 허용

### 테스트 결과

- [X] 테스트 빌드 통과