### PR TITLE
refactor: 유튜버 여행코스 목록 조회 시 url 반환 추가

### DIFF
--- a/src/main/java/org/backend/travelcourse/dto/TravelCourseListResponse.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourseListResponse.java
@@ -9,7 +9,9 @@ public record TravelCourseListResponse(
         boolean isShared,
         int days,
         String creatorName,
-        CreatorType creatorType
+        CreatorType creatorType,
+        String youtubeUrl,
+        String youtubeImageUrl
 ) {
     public static TravelCourseListResponse toResponseListDto(TravelCourse travelCourse) {
         return new TravelCourseListResponse(
@@ -18,7 +20,9 @@ public record TravelCourseListResponse(
                 travelCourse.isShared(),
                 travelCourse.getDays(),
                 travelCourse.getCreatorName(),
-                travelCourse.getCreatorType()
+                travelCourse.getCreatorType(),
+                travelCourse.getYoutubeUrl(),
+                travelCourse.getYoutubeImageUrl()
         );
     }
 }


### PR DESCRIPTION
### 개요

- 유튜버 여행코스 목록 조회시 youtube 썸네일 및 링크 반환 요구

### 반영 브랜치

- `refactor/youtube-url` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- TravelCourseListResponse에 URL 값 추가

### 테스트 결과

- [X] 반환 리스트 포함되는 것 확인