### PR TITLE
feat: 유튜버 랜덤코스 파라미터 타입 수정 및 컨트롤러 테스트 구현

### DIFF
--- a/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
+++ b/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
@@ -53,7 +53,7 @@ public class TravelCourseService {
 
     @Transactional(readOnly = true)
     public TravelCourseResponse findRandomYoutuberTravelCourseByCreatorType() {
-        TravelCourse travelCourse = travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER)
+        TravelCourse travelCourse = travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString())
                 .orElseThrow(() -> new TravelCourseNotFoundException(ResponseCode.COURSE_NOT_FOUND));
 
         List<TravelCourseDetailResponse> travelCourseDetailResponses = travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse)

--- a/src/main/java/org/backend/travelcourse/domain/TravelCourseRepository.java
+++ b/src/main/java/org/backend/travelcourse/domain/TravelCourseRepository.java
@@ -13,5 +13,5 @@ public interface TravelCourseRepository extends JpaRepository<TravelCourse, Long
             + " FROM travel_course t"
             + " WHERE t.creator_type = :creatorType"
             + " ORDER BY RAND() LIMIT 1", nativeQuery = true)
-    Optional<TravelCourse> findRandomTravelCourseByCreatorType(CreatorType creatorType);
+    Optional<TravelCourse> findRandomTravelCourseByCreatorType(String creatorType);
 }

--- a/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
+++ b/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
@@ -168,7 +168,7 @@ public class TravelCourseServiceTest {
     @DisplayName("유튜버 코스를 랜덤으로 1개 조회 테스트입니다.")
     void testFindRandomYoutuberTravelCourseByCreatorType() {
         // when
-        when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER))
+        when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString()))
                 .thenReturn(Optional.of(travelCourse));
         when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse))
                 .thenReturn(Optional.of(travelCourseDetails));
@@ -184,7 +184,7 @@ public class TravelCourseServiceTest {
     @DisplayName("유튜버 코스를 랜덤으로 1개 조회할 때 여행코스가 존재하지 않아 발생하는 예외 테스트입니다.")
     void testFindRandomYoutuberTravelCourseByCreatorTypeException() {
         // when
-        when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER))
+        when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString()))
                 .thenThrow(TravelCourseNotFoundException.class);
 
         // then
@@ -195,7 +195,7 @@ public class TravelCourseServiceTest {
     @DisplayName("유튜버 코스를 랜덤으로 1개 조회할 때 여행코스 상세 정보가 존재하지 않아 발생하는 예외 테스트입니다.")
     void testFindRandomYoutuberTravelCourseByCreatorTypeDetailException() {
         // when
-        when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER))
+        when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString()))
                 .thenReturn(Optional.of(travelCourse));
         when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse))
                 .thenThrow(TravelCourseDetailNotFoundException.class);

--- a/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
+++ b/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
@@ -198,6 +198,20 @@ public class TravelCourseControllerTest {
                 .contentType("application/json"))
                 .andExpect(jsonPath("$.body.data[0].creatorType").value("YOUTUBER"))
                 .andExpect(jsonPath("$.body.data[0].creatorName").value("테스트TV"));
+    }
 
+    @Test
+    @DisplayName("유튜버 여행코스 정보 랜덤 조회 API를 테스트합니다.")
+    @WithMockUser(username = "test User", roles = "USER")
+    void testRandomYoutuberTravelCourse() throws Exception {
+        // when
+        when(travelCourseService.findRandomYoutuberTravelCourseByCreatorType()).thenReturn(TravelCourseResponse.toResponseDto(travelCourse, List.of()));
+
+        // then
+        mockMvc.perform(get("/api/travel-courses/youtubers/random")
+                        .with(SecurityMockMvcRequestPostProcessors.csrf())
+                        .contentType("application/json"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.body.data.courseName").value("나만의 코스"));
     }
 }


### PR DESCRIPTION
### 개요

- 유튜버 랜덤코스 조회 기능 수정 및 컨트롤러 테스트

### 반영 브랜치

- `feature/random-travelcourse-1` -> `main`

### PR 타입

- 기능 추가
- 리팩터링

### 변경 사항

- 유튜버 여행코스 랜덤 조회 api 테스트
- 유튜버 여행코스 랜덤 조회 쿼리 파라미터 타입 변경

### 테스트 결과

- [X] 유튜버 랜덤조회 기능 컨트롤러 테스트
- [ ] 유튜버 랜덤조회 기능 확인