### PR TITLE
feat: 유튜버 여행코스 리스트 조회 시 필터 도입

### DIFF
--- a/src/main/java/org/backend/place/domain/Place.java
+++ b/src/main/java/org/backend/place/domain/Place.java
@@ -19,10 +19,10 @@ public class Place extends BaseTimeEntity {
     @Column(nullable = false)
     private String placeName;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private Double latitude;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private Double longitude;
 
     public Place() {

--- a/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
+++ b/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
@@ -12,6 +12,7 @@ import org.backend.travelcourse.exception.TravelCourseNotFoundException;
 import org.backend.travelcoursedetail.domain.TravelCourseDetailRepository;
 import org.backend.travelcoursedetail.dto.TravelCourseDetailResponse;
 import org.backend.travelcoursedetail.excetion.TravelCourseDetailNotFoundException;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,6 +63,13 @@ public class TravelCourseService {
                 .toList();
 
         return TravelCourseResponse.toResponseDto(travelCourse, travelCourseDetailResponses);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TravelCourseListResponse> findYoutuberTravelCourseByViewCount(Sort sort) {
+        return travelCourseRepository.findByCreatorType(CreatorType.YOUTUBER, sort)
+                .orElseThrow(() -> new TravelCourseNotFoundException(ResponseCode.COURSE_NOT_FOUND))
+                .stream().map(TravelCourseListResponse::toResponseListDto).toList();
     }
 
     @Transactional

--- a/src/main/java/org/backend/travelcourse/controller/TravelCourseController.java
+++ b/src/main/java/org/backend/travelcourse/controller/TravelCourseController.java
@@ -14,12 +14,14 @@ import org.backend.travelcourse.dto.TravelCourseResponse;
 import org.backend.travelcourse.application.TravelCourseService;
 import org.backend.travelcourse.exception.TravelCourseBadRequestException;
 import org.backend.travelcoursedetail.application.TravelCourseDetailService;
+import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -72,6 +74,13 @@ public class TravelCourseController {
     @Operation(summary = "유튜버의 여행코스 랜덤 조회", description = "저장된 유튜버의 여행코스 중 랜덤으로 1개를 조회하기 위해 사용하는 API")
     public ApiResponse<TravelCourseResponse> randomYoutuberTravelCourse() {
         return ApiResponse.success(ResponseCode.COURSE_YOUTUBER_READ_SUCCESS, travelCourseService.findRandomYoutuberTravelCourseByCreatorType());
+    }
+
+    @GetMapping("/travel-courses/youtubers/reviews")
+    @Operation(summary = "유튜버의 여행코스 조회수 필터 조회", description = "유튜버의 여행코스 중 조회수가 높은 순서대로 조회하기 위해 사용하는 API")
+    public ApiResponse<List<TravelCourseListResponse>> youtuberTravelCourseListByViewCount(@RequestParam String sortDirection) {
+        return ApiResponse.success(ResponseCode.COURSE_YOUTUBER_READ_SUCCESS,
+                travelCourseService.findYoutuberTravelCourseByViewCount(Sort.by(Sort.Direction.fromString(sortDirection), "viewCount")));
     }
 
     @DeleteMapping("/travel-courses/{id}")

--- a/src/main/java/org/backend/travelcourse/domain/TravelCourse.java
+++ b/src/main/java/org/backend/travelcourse/domain/TravelCourse.java
@@ -22,9 +22,6 @@ public class TravelCourse extends BaseTimeEntity {
     private String courseName;
 
     @Column(nullable = false)
-    private boolean isShared;
-
-    @Column(nullable = false)
     private int days;
 
     @Column(nullable = true, length = 500)
@@ -37,56 +34,51 @@ public class TravelCourse extends BaseTimeEntity {
     @Column(nullable = true, name = "youtube_url", length = 1000)
     private String youtubeUrl;
 
-    @Column(nullable = true, name = "youtuber_image_url", length = 1000)
+    @Column(nullable = true, name = "youtube_image_url", length = 1000)
     private String youtubeImageUrl;
+
+    @Column(nullable = true, name = "view_count")
+    private Long viewCount;
 
     public TravelCourse(Long travelCourseId,
                         String courseName,
-                        boolean isShared,
                         int days,
                         String creatorName,
                         CreatorType creatorType,
                         String youtubeUrl,
-                        String youtubeImageUrl) {
+                        String youtubeImageUrl,
+                        Long viewCount) {
         this.travelCourseId = travelCourseId;
         this.courseName = courseName;
-        this.isShared = isShared;
         this.days = days;
         this.creatorName = creatorName;
         this.creatorType = creatorType;
         this.youtubeUrl = youtubeUrl;
         this.youtubeImageUrl = youtubeImageUrl;
+        this.viewCount = viewCount;
     }
 
     public TravelCourse(String courseName,
-                        boolean isShared,
                         int days,
                         String creatorName,
                         CreatorType creatorType,
                         String youtubeUrl) {
         this.courseName = courseName;
-        this.isShared = isShared;
         this.days = days;
         this.creatorName = creatorName;
         this.creatorType = creatorType;
         this.youtubeUrl = youtubeUrl;
     }
 
-
-    public TravelCourse(String courseName, boolean isShared, int days) {
+    public TravelCourse(String courseName, int days) {
         this.courseName = courseName;
-        this.isShared = isShared;
         this.days = days;
     }
 
     public TravelCourse() {}
 
-    public void setCreatorName(String creatorName) {
-        this.creatorName = creatorName;
-    }
-
-    public void setCreatorType(CreatorType creatorType) {
-        this.creatorType = creatorType;
+    public Long getViewCount() {
+        return viewCount;
     }
 
     public String getYoutubeUrl() {
@@ -103,10 +95,6 @@ public class TravelCourse extends BaseTimeEntity {
 
     public String getCourseName() {
         return courseName;
-    }
-
-    public boolean isShared() {
-        return isShared;
     }
 
     public int getDays() {

--- a/src/main/java/org/backend/travelcourse/domain/TravelCourseRepository.java
+++ b/src/main/java/org/backend/travelcourse/domain/TravelCourseRepository.java
@@ -2,6 +2,7 @@ package org.backend.travelcourse.domain;
 
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
@@ -14,4 +15,6 @@ public interface TravelCourseRepository extends JpaRepository<TravelCourse, Long
             + " WHERE t.creator_type = :creatorType"
             + " ORDER BY RAND() LIMIT 1", nativeQuery = true)
     Optional<TravelCourse> findRandomTravelCourseByCreatorType(String creatorType);
+
+    Optional<List<TravelCourse>> findByCreatorType(CreatorType creatorType, Sort sort);
 }

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourseListResponse.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourseListResponse.java
@@ -6,23 +6,23 @@ import org.backend.travelcourse.domain.TravelCourse;
 public record TravelCourseListResponse(
         Long id,
         String courseName,
-        boolean isShared,
         int days,
         String creatorName,
         CreatorType creatorType,
         String youtubeUrl,
-        String youtubeImageUrl
+        String youtubeImageUrl,
+        Long viewCount
 ) {
     public static TravelCourseListResponse toResponseListDto(TravelCourse travelCourse) {
         return new TravelCourseListResponse(
                 travelCourse.getTravelCourseId(),
                 travelCourse.getCourseName(),
-                travelCourse.isShared(),
                 travelCourse.getDays(),
                 travelCourse.getCreatorName(),
                 travelCourse.getCreatorType(),
                 travelCourse.getYoutubeUrl(),
-                travelCourse.getYoutubeImageUrl()
+                travelCourse.getYoutubeImageUrl(),
+                travelCourse.getViewCount()
         );
     }
 }

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourseRequest.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourseRequest.java
@@ -6,7 +6,6 @@ import org.backend.travelcourse.domain.TravelCourse;
 
 public record TravelCourseRequest(
         String courseName,
-        boolean isShared,
         int days,
         List<PlaceRequest> places
 ) {
@@ -14,7 +13,6 @@ public record TravelCourseRequest(
     public TravelCourse toEntity() {
         return new TravelCourse(
                 courseName,
-                isShared,
                 days
         );
     }

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourseResponse.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourseResponse.java
@@ -8,25 +8,25 @@ import org.backend.travelcoursedetail.dto.TravelCourseDetailResponse;
 public record TravelCourseResponse(
         Long id,
         String courseName,
-        boolean isShared,
         int days,
         String creatorName,
         CreatorType creatorType,
         String youtubeUrl,
         String youtubeImageUrl,
-        List<TravelCourseDetailResponse> travelCourseDetailResponse
+        List<TravelCourseDetailResponse> travelCourseDetailResponse,
+        Long viewCount
 ) {
     public static TravelCourseResponse toResponseDto(TravelCourse travelCourse, List<TravelCourseDetailResponse> travelCourseDetailResponses) {
         return new TravelCourseResponse(
                 travelCourse.getTravelCourseId(),
                 travelCourse.getCourseName(),
-                travelCourse.isShared(),
                 travelCourse.getDays(),
                 travelCourse.getCreatorName(),
                 travelCourse.getCreatorType(),
                 travelCourse.getYoutubeUrl(),
                 travelCourse.getYoutubeImageUrl(),
-                travelCourseDetailResponses
+                travelCourseDetailResponses,
+                travelCourse.getViewCount()
         );
     }
 }

--- a/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
+++ b/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.context.ActiveProfiles;
 
 @ExtendWith(MockitoExtension.class)
@@ -55,7 +56,6 @@ public class TravelCourseServiceTest {
 
         travelCourseRequest = new TravelCourseRequest(
                 "나만의 코스",
-                false,
                 2,
                 List.of()
         );
@@ -63,12 +63,12 @@ public class TravelCourseServiceTest {
         travelCourse = new TravelCourse(
                 1L,
                 "나만의 코스",
-                false,
                 2,
                 "테스트TV",
                 CreatorType.YOUTUBER,
                 null,
-                null);
+                null,
+                100000L);
 
         travelCourseDetails = List.of(
                 new TravelCourseDetail(travelCourse, place1, 1, 1),
@@ -151,7 +151,7 @@ public class TravelCourseServiceTest {
     }
 
     @Test
-    @DisplayName("유튜버 코스 조회를 테스트입니다.")
+    @DisplayName("유튜버 코스 리스트 조회 테스트입니다.")
     void testFindYoutuberTravelCourse() {
         // when
         when(travelCourseRepository.findTravelCoursesByCreatorType(CreatorType.YOUTUBER))
@@ -202,5 +202,21 @@ public class TravelCourseServiceTest {
 
         // then
         assertThrows(TravelCourseDetailNotFoundException.class, () -> travelCourseService.findRandomYoutuberTravelCourseByCreatorType());
+    }
+
+    @Test
+    @DisplayName("유튜버 코스 리스트 필터 조회 테스트입니다.")
+    void testFindYoutuberTravelCourseByViewCount() {
+        // when
+        Sort sort = Sort.by(Sort.Direction.fromString("ASC"), "viewCount");
+        when(travelCourseRepository.findByCreatorType(CreatorType.YOUTUBER, sort))
+                .thenReturn(Optional.of(List.of(travelCourse)));
+
+        List<TravelCourseListResponse> responses = travelCourseService.findYoutuberTravelCourseByViewCount(sort);
+
+        // then
+        assertNotNull(responses);
+        assertEquals(travelCourse.getCourseName(), responses.get(0).courseName());
+        assertEquals(travelCourse.getViewCount(), responses.get(0).viewCount());
     }
 }

--- a/src/test/java/org/backend/travelcoursedetail/application/TravelCourseDetailServiceTest.java
+++ b/src/test/java/org/backend/travelcoursedetail/application/TravelCourseDetailServiceTest.java
@@ -35,12 +35,12 @@ public class TravelCourseDetailServiceTest {
         TravelCourse travelCourse = new TravelCourse(
                 1L,
                 "나만의 코스",
-                false,
                 2,
                 "테스트TV",
                 CreatorType.YOUTUBER,
                 null,
-                null
+                null,
+                10000L
         );
 
         List<Place> places = List.of(


### PR DESCRIPTION
### 개요

- 유튜버 리스트 조회 시 조회수를 기준으로 필터 조회를 요구

### 반영 브랜치

- `feature/filter-travelcourse` -> `main`

### PR 타입

- 기능 추가

### 변경 사항

- TravelCourseController 필터 조회 API 추가
- TravelCourseService 필터 조회 로직 추가
- Service, Controller test 추가
- 여행 코스에 viewCount 컬럼 추가
- 사용하지 않는 isShared 컬럼 삭제

### 테스트 결과

- [X] 테스트 빌드 통과
- [X] Service, Controller Test 통과