### PR TITLE
refactor: travelCourseDetail 조회 시 일정에 맞는 순서 보장

### DIFF
--- a/src/main/java/org/backend/place/domain/PlaceRepository.java
+++ b/src/main/java/org/backend/place/domain/PlaceRepository.java
@@ -3,12 +3,13 @@ package org.backend.place.domain;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-    @Query(value = "Select * "
-            + "from places l "
-            + "where l.latitude = :latitude "
+    @Query(value = "SELECT * "
+            + "FROM places l "
+            + "WHERE l.latitude = :latitude "
             + "And l.longitude = :longitude", nativeQuery = true)
-    Optional<Place> findByLatitudeAndLongitude(Double latitude, Double longitude);
+    Optional<Place> findByLatitudeAndLongitude(@Param("latitude") Double latitude, @Param("longitude") Double longitude);
 }

--- a/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
+++ b/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
@@ -36,7 +36,7 @@ public class TravelCourseService {
         TravelCourse travelCourse = travelCourseRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_NOT_FOUND));
 
-        List<TravelCourseDetailResponse> travelCourseDetailResponses = travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse)
+        List<TravelCourseDetailResponse> travelCourseDetailResponses = travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId())
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_DETAIL_NOT_FOUND))
                 .stream().map(TravelCourseDetailResponse::toResponseDto)
                 .toList();
@@ -56,7 +56,7 @@ public class TravelCourseService {
         TravelCourse travelCourse = travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString())
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_NOT_FOUND));
 
-        List<TravelCourseDetailResponse> travelCourseDetailResponses = travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse)
+        List<TravelCourseDetailResponse> travelCourseDetailResponses = travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId())
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_DETAIL_NOT_FOUND))
                 .stream().map(TravelCourseDetailResponse::toResponseDto)
                 .toList();

--- a/src/main/java/org/backend/travelcoursedetail/domain/TravelCourseDetailRepository.java
+++ b/src/main/java/org/backend/travelcoursedetail/domain/TravelCourseDetailRepository.java
@@ -4,8 +4,14 @@ import java.util.List;
 import java.util.Optional;
 import org.backend.travelcourse.domain.TravelCourse;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TravelCourseDetailRepository extends JpaRepository<TravelCourseDetail, Long> {
 
-    Optional<List<TravelCourseDetail>> findTravelCourseDetailsByTravelCourse(TravelCourse travelCourse);
+    @Query(value = "SELECT * "
+            + "FROM travel_course_detail "
+            + "WHERE travel_course_id = :travelCourseId "
+            + "ORDER BY course_day ASC, order_in_day ASC",nativeQuery = true)
+    Optional<List<TravelCourseDetail>> findTravelCourseDetailsByTravelCourseId(@Param("travelCourseId") Long travelCourseId);
 }

--- a/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
+++ b/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
@@ -96,14 +96,15 @@ public class TravelCourseServiceTest {
     void testFindById() {
         // when
         when(travelCourseRepository.findById(1L)).thenReturn(Optional.of(travelCourse));
-        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse))
+        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId()))
                 .thenReturn(Optional.of(travelCourseDetails));
         TravelCourseResponse response = travelCourseService.findById(1L);
 
         // then
         assertNotNull(response);
         assertEquals("나만의 코스", response.courseName());
-        assertEquals(travelCourseDetails.get(0).getOrderInDay(), response.travelCourseDetailResponse().get(0).orderInDay());
+        assertEquals(travelCourseDetails.get(0).getCourseDay(), response.travelCourseDetailResponse().get(0).day());
+        assertEquals(travelCourseDetails.get(3).getOrderInDay(), response.travelCourseDetailResponse().get(3).orderInDay());
     }
 
     @Test
@@ -121,7 +122,7 @@ public class TravelCourseServiceTest {
     void testTravelCourseDetailNotFoundException() {
         // when
         when(travelCourseRepository.findById(1L)).thenReturn(Optional.of(travelCourse));
-        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse))
+        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId()))
                 .thenThrow(NotFoundException.class);
 
         // then
@@ -169,7 +170,7 @@ public class TravelCourseServiceTest {
         // when
         when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString()))
                 .thenReturn(Optional.of(travelCourse));
-        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse))
+        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId()))
                 .thenReturn(Optional.of(travelCourseDetails));
 
         TravelCourseResponse response = travelCourseService.findRandomYoutuberTravelCourseByCreatorType();
@@ -196,7 +197,7 @@ public class TravelCourseServiceTest {
         // when
         when(travelCourseRepository.findRandomTravelCourseByCreatorType(CreatorType.YOUTUBER.toString()))
                 .thenReturn(Optional.of(travelCourse));
-        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourse(travelCourse))
+        when(travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId()))
                 .thenThrow(NotFoundException.class);
 
         // then

--- a/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
+++ b/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
@@ -263,7 +263,8 @@ public class TravelCourseControllerTest {
                         .contentType("application/json"))
                 .andExpect(jsonPath("$.body.data[0].creatorType").value("YOUTUBER"))
                 .andExpect(jsonPath("$.body.data[0].creatorName").value("테스트TV"))
-                .andExpect(jsonPath("$.body.data[0].viewCount").value(travelCourse1.getViewCount()));
+                .andExpect(jsonPath("$.body.data[0].viewCount").value(travelCourse1.getViewCount()))
+                .andDo(print());
     }
 
     @Test


### PR DESCRIPTION
### 개요

- 여행코스 조회 시 일정에 맞는 순서 보장 필요

### 반영 브랜치

- `refactor/travelcoursedetail-api` -> `main`

### PR 타입

- 리팩터링

### 변경 사항

- 쿼리 courseDay, orderInDay 조회 쿼리 오름차순 적용
- 조회 로직 테스트 수정

### 테스트 결과

- [X] 조회 시 오름차순 조회 확인
- [X] 테스트 빌드 통과