### PR TITLE
fix: 로그 파일 저장 날짜 변수명 변경

### DIFF
--- a/src/main/resources/error-appender.xml
+++ b/src/main/resources/error-appender.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
     <appender name="FILE-ERROR" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>../logs/error/${BY_DATE}.log</file>
+        <file>../logs/error/%d{yyyy-MM-dd}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>../logs/backup/error/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>

--- a/src/main/resources/info-appender.xml
+++ b/src/main/resources/info-appender.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
     <appender name="FILE-INFO" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>../logs/info/${BY_DATE}.log</file>
+        <file>../logs/info/%d{yyyy-MM-dd}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>../logs/backup/info/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>

--- a/src/main/resources/warn-appender.xml
+++ b/src/main/resources/warn-appender.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <included>
     <appender name="FILE-WARN" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>../logs/warn/${BY_DATE}.log</file>
+        <file>../logs/warn/%d{yyyy-MM-dd}.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>../logs/backup/warn/%d{yyyy-MM-dd}.%i.log</fileNamePattern>
             <maxFileSize>50MB</maxFileSize>


### PR DESCRIPTION
## 개요

- 운영 서버에서 로그 내역 저장 파일이 생기지 않는 문제 발생

### PR 타입

- 버그 해결

### 변경 사항

- 날짜 변수명을 인식하지 못하는 문제를 `${yyyy-MM-dd}`로 수정

### 테스트 결과

- [X] 로그 파일이 정상적으로 저장되는지 확인