### PR TITLE
Perf: elasticache 도입

### DIFF
--- a/.github/workflows/deploy-BE.yml
+++ b/.github/workflows/deploy-BE.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - perf/50-elasticache-redis-lettuce
 
 jobs:
   test:

--- a/.github/workflows/deploy-BE.yml
+++ b/.github/workflows/deploy-BE.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - perf/50-elasticache-redis-lettuce
 
 jobs:
   test:

--- a/build.gradle
+++ b/build.gradle
@@ -36,9 +36,6 @@ dependencies {
     // MySQL
     implementation 'com.mysql:mysql-connector-j'
 
-    // h2
-    runtimeOnly 'com.h2database:h2'
-
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 

--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
     // h2
     runtimeOnly 'com.h2database:h2'
 
+    // redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/org/backend/BackendApplication.java
+++ b/src/main/java/org/backend/BackendApplication.java
@@ -2,8 +2,10 @@ package org.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 @SpringBootApplication
+@EnableCaching
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/org/backend/global/ServerController.java
+++ b/src/main/java/org/backend/global/ServerController.java
@@ -2,6 +2,7 @@ package org.backend.global;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -12,6 +13,7 @@ public class ServerController {
 
     @GetMapping("/api/hello")
     @Operation(summary = "서버 동작 확인", description = "서버 동작을 확인하기 위해 사용하는 API")
+    @Cacheable(value = "health", key = "'hello'")
     public String hello() {
         return "Hello, World.";
     }

--- a/src/main/java/org/backend/global/ServerController.java
+++ b/src/main/java/org/backend/global/ServerController.java
@@ -13,7 +13,6 @@ public class ServerController {
 
     @GetMapping("/api/hello")
     @Operation(summary = "서버 동작 확인", description = "서버 동작을 확인하기 위해 사용하는 API")
-    @Cacheable(value = "health", key = "'hello'")
     public String hello() {
         return "Hello, World.";
     }

--- a/src/main/java/org/backend/global/config/RedisCacheConfig.java
+++ b/src/main/java/org/backend/global/config/RedisCacheConfig.java
@@ -16,11 +16,8 @@ public class RedisCacheConfig {
     @Bean
     public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
         RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
-                // 캐시 만료 시간 설정 (예: 1시간)
                 .entryTtl(Duration.ofHours(1))
-                // null 값 캐시 안 함
                 .disableCachingNullValues()
-                // 직렬화 설정 (키와 값을 문자열로 직렬화)
                 .serializeKeysWith(RedisSerializationContext.SerializationPair
                         .fromSerializer(new StringRedisSerializer()))
                 .serializeValuesWith(RedisSerializationContext.SerializationPair

--- a/src/main/java/org/backend/global/config/RedisCacheConfig.java
+++ b/src/main/java/org/backend/global/config/RedisCacheConfig.java
@@ -1,0 +1,33 @@
+package org.backend.global.config;
+
+import java.time.Duration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisCacheConfig {
+
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration defaultCacheConfig = RedisCacheConfiguration.defaultCacheConfig()
+                // 캐시 만료 시간 설정 (예: 1시간)
+                .entryTtl(Duration.ofHours(1))
+                // null 값 캐시 안 함
+                .disableCachingNullValues()
+                // 직렬화 설정 (키와 값을 문자열로 직렬화)
+                .serializeKeysWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(defaultCacheConfig)
+                .build();
+    }
+}

--- a/src/main/java/org/backend/global/config/RedisConfig.java
+++ b/src/main/java/org/backend/global/config/RedisConfig.java
@@ -1,0 +1,29 @@
+package org.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.redis.host}")
+    private String REDIS_HOST;
+
+    @Value("${spring.redis.port}")
+    private int REDIS_PORT;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
+
+        configuration.setHostName(REDIS_HOST);
+        configuration.setPort(REDIS_PORT);
+
+        return new LettuceConnectionFactory(configuration);
+    }
+
+}

--- a/src/main/java/org/backend/global/config/RedisConfig.java
+++ b/src/main/java/org/backend/global/config/RedisConfig.java
@@ -10,11 +10,14 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 @Configuration
 public class RedisConfig {
 
-    @Value("${spring.redis.host}")
+    @Value("${spring.data.redis.host}")
     private String REDIS_HOST;
 
-    @Value("${spring.redis.port}")
+    @Value("${spring.data.redis.port}")
     private int REDIS_PORT;
+
+    @Value("${spring.data.redis.password}")
+    private String REDIS_PASSWORD;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -22,6 +25,7 @@ public class RedisConfig {
 
         configuration.setHostName(REDIS_HOST);
         configuration.setPort(REDIS_PORT);
+        configuration.setPassword(REDIS_PASSWORD);
 
         return new LettuceConnectionFactory(configuration);
     }

--- a/src/main/java/org/backend/global/config/RedisConfig.java
+++ b/src/main/java/org/backend/global/config/RedisConfig.java
@@ -16,19 +16,11 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int REDIS_PORT;
 
-    // 로컬에서만 해당
-//    @Value("${spring.data.redis.password}")
-//    private String REDIS_PASSWORD;
-
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
-
         configuration.setHostName(REDIS_HOST);
         configuration.setPort(REDIS_PORT);
-//        configuration.setPassword(REDIS_PASSWORD);
-
         return new LettuceConnectionFactory(configuration);
     }
-
 }

--- a/src/main/java/org/backend/global/config/RedisConfig.java
+++ b/src/main/java/org/backend/global/config/RedisConfig.java
@@ -16,8 +16,9 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int REDIS_PORT;
 
-    @Value("${spring.data.redis.password}")
-    private String REDIS_PASSWORD;
+    // 로컬에서만 해당
+//    @Value("${spring.data.redis.password}")
+//    private String REDIS_PASSWORD;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -25,7 +26,7 @@ public class RedisConfig {
 
         configuration.setHostName(REDIS_HOST);
         configuration.setPort(REDIS_PORT);
-        configuration.setPassword(REDIS_PASSWORD);
+//        configuration.setPassword(REDIS_PASSWORD);
 
         return new LettuceConnectionFactory(configuration);
     }

--- a/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
+++ b/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
@@ -5,10 +5,10 @@ import org.backend.global.exception.NotFoundException;
 import org.backend.global.response.ResponseCode;
 import org.backend.travelcourse.domain.CreatorType;
 import org.backend.travelcourse.dto.TravelCourseListResponse;
-import org.backend.travelcourse.dto.TravelCourseRequest;
 import org.backend.travelcourse.dto.TravelCourseResponse;
 import org.backend.travelcourse.domain.TravelCourse;
 import org.backend.travelcourse.domain.TravelCourseRepository;
+import org.backend.travelcourse.dto.TravelCourses;
 import org.backend.travelcoursedetail.domain.TravelCourseDetailRepository;
 import org.backend.travelcoursedetail.dto.TravelCourseDetailResponse;
 import org.springframework.cache.annotation.Cacheable;
@@ -42,11 +42,11 @@ public class TravelCourseService {
     }
 
     @Transactional(readOnly = true)
-//    @Cacheable(value = "travelCourseList", key = "'allTravelCourses'")
-    public List<TravelCourseListResponse> findYoutuberTravelCourseByCreatorType() {
-        return travelCourseRepository.findTravelCoursesByCreatorType(CreatorType.YOUTUBER)
+    @Cacheable(value = "travelCourseList", key = "'allTravelCourses'")
+    public TravelCourses findYoutuberTravelCourseByCreatorType() {
+        return new TravelCourses(travelCourseRepository.findTravelCoursesByCreatorType(CreatorType.YOUTUBER)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_NOT_FOUND_YOUTUBER))
-                .stream().map(TravelCourseListResponse::toResponseListDto).toList();
+                .stream().map(TravelCourseListResponse::toResponseListDto).toList().stream().toList());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
+++ b/src/main/java/org/backend/travelcourse/application/TravelCourseService.java
@@ -11,6 +11,7 @@ import org.backend.travelcourse.domain.TravelCourse;
 import org.backend.travelcourse.domain.TravelCourseRepository;
 import org.backend.travelcoursedetail.domain.TravelCourseDetailRepository;
 import org.backend.travelcoursedetail.dto.TravelCourseDetailResponse;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,9 +27,10 @@ public class TravelCourseService {
         this.travelCourseDetailRepository = travelCourseDetailRepository;
     }
 
-    @Transactional(readOnly = true)
-    public TravelCourseResponse findById(Long id) {
-        TravelCourse travelCourse = travelCourseRepository.findById(id)
+    @Transactional
+    @Cacheable(value = "travelCourse", key = "'TravelCourse_' + #travelCourseId")
+    public TravelCourseResponse findById(Long travelCourseId) {
+        TravelCourse travelCourse = travelCourseRepository.findById(travelCourseId)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_NOT_FOUND));
 
         List<TravelCourseDetailResponse> travelCourseDetailResponses = travelCourseDetailRepository.findTravelCourseDetailsByTravelCourseId(travelCourse.getTravelCourseId())
@@ -40,6 +42,7 @@ public class TravelCourseService {
     }
 
     @Transactional(readOnly = true)
+//    @Cacheable(value = "travelCourseList", key = "'allTravelCourses'")
     public List<TravelCourseListResponse> findYoutuberTravelCourseByCreatorType() {
         return travelCourseRepository.findTravelCoursesByCreatorType(CreatorType.YOUTUBER)
                 .orElseThrow(() -> new NotFoundException(ResponseCode.COURSE_NOT_FOUND_YOUTUBER))

--- a/src/main/java/org/backend/travelcourse/controller/TravelCourseController.java
+++ b/src/main/java/org/backend/travelcourse/controller/TravelCourseController.java
@@ -13,6 +13,7 @@ import org.backend.travelcourse.dto.TravelCourseListResponse;
 import org.backend.travelcourse.dto.TravelCourseRequest;
 import org.backend.travelcourse.dto.TravelCourseResponse;
 import org.backend.travelcourse.application.TravelCourseService;
+import org.backend.travelcourse.dto.TravelCourses;
 import org.backend.travelcoursedetail.application.TravelCourseDetailService;
 import org.springframework.data.domain.Sort;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -43,7 +44,7 @@ public class TravelCourseController {
 
     @GetMapping("/travel-courses/youtubers")
     @Operation(summary = "유튜버의 여행코스 목록 조회", description = "저장된 유튜버의 여행코스 목록을 조회하기 위해 사용하는 API")
-    public ApiResponse<List<TravelCourseListResponse>> youtuberTravelCourseList() {
+    public ApiResponse<TravelCourses> youtuberTravelCourseList() {
         return ApiResponse.success(ResponseCode.COURSE_YOUTUBER_READ_SUCCESS, travelCourseService.findYoutuberTravelCourseByCreatorType());
     }
 

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourses.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourses.java
@@ -1,0 +1,16 @@
+package org.backend.travelcourse.dto;
+
+import java.util.List;
+
+public class TravelCourses {
+
+    private final List<TravelCourseListResponse> travelCourses;
+
+    public TravelCourses(List<TravelCourseListResponse> travelCourses) {
+        this.travelCourses = travelCourses;
+    }
+
+    public List<TravelCourseListResponse> getTravelCourses() {
+        return travelCourses;
+    }
+}

--- a/src/main/java/org/backend/travelcourse/dto/TravelCourses.java
+++ b/src/main/java/org/backend/travelcourse/dto/TravelCourses.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 public class TravelCourses {
 
-    private final List<TravelCourseListResponse> travelCourses;
+    private List<TravelCourseListResponse> travelCourses;
+
+    public TravelCourses(){}
 
     public TravelCourses(List<TravelCourseListResponse> travelCourses) {
         this.travelCourses = travelCourses;

--- a/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
+++ b/src/test/java/org/backend/travelcourse/application/TravelCourseServiceTest.java
@@ -12,8 +12,8 @@ import org.backend.travelcourse.domain.CreatorType;
 import org.backend.travelcourse.domain.TravelCourse;
 import org.backend.travelcourse.domain.TravelCourseRepository;
 import org.backend.travelcourse.dto.TravelCourseListResponse;
-import org.backend.travelcourse.dto.TravelCourseRequest;
 import org.backend.travelcourse.dto.TravelCourseResponse;
+import org.backend.travelcourse.dto.TravelCourses;
 import org.backend.travelcoursedetail.domain.TravelCourseDetail;
 import org.backend.travelcoursedetail.domain.TravelCourseDetailRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +40,6 @@ public class TravelCourseServiceTest {
     private TravelCourseService travelCourseService;
 
     private TravelCourse travelCourse;
-    private TravelCourseRequest travelCourseRequest;
     private List<TravelCourseDetail> travelCourseDetails;
 
     @BeforeEach
@@ -51,12 +50,6 @@ public class TravelCourseServiceTest {
         Place place4 = new Place(4L, "Place4", 37.7749, -122.4194);
         Place place5 = new Place(5L, "Place5", 12.7749, -122.4194);
         Place place6 = new Place(6L, "Place6", 16.7749, -122.4194);
-
-        travelCourseRequest = new TravelCourseRequest(
-                "나만의 코스",
-                2,
-                List.of()
-        );
 
         travelCourse = new TravelCourse(
                 1L,
@@ -123,11 +116,11 @@ public class TravelCourseServiceTest {
         when(travelCourseRepository.findTravelCoursesByCreatorType(CreatorType.YOUTUBER))
                 .thenReturn(Optional.of(List.of(travelCourse)));
 
-        List<TravelCourseListResponse> responses = travelCourseService.findYoutuberTravelCourseByCreatorType();
+        TravelCourses responses = travelCourseService.findYoutuberTravelCourseByCreatorType();
 
         // then
         assertNotNull(responses);
-        assertEquals(travelCourse.getCourseName(), responses.get(0).courseName());
+        assertEquals(travelCourse.getCourseName(), responses.getTravelCourses().get(0).courseName());
     }
 
     @Test

--- a/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
+++ b/src/test/java/org/backend/travelcourse/controller/TravelCourseControllerTest.java
@@ -2,7 +2,6 @@ package org.backend.travelcourse.controller;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -18,8 +17,8 @@ import org.backend.travelcourse.application.TravelCourseService;
 import org.backend.travelcourse.domain.CreatorType;
 import org.backend.travelcourse.domain.TravelCourse;
 import org.backend.travelcourse.dto.TravelCourseListResponse;
-import org.backend.travelcourse.dto.TravelCourseRequest;
 import org.backend.travelcourse.dto.TravelCourseResponse;
+import org.backend.travelcourse.dto.TravelCourses;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -43,12 +42,8 @@ public class TravelCourseControllerTest {
     @Autowired
     private ObjectMapper mapper;
 
-    private TravelCourseRequest validRequest;
-    private TravelCourseRequest invalidRequest;
     private TravelCourse travelCourse;
     private Long travelCourseId;
-    private List<PlaceRequest> placeRequests;
-    private List<Place> places1;
 
     @BeforeEach
     void setUp() {
@@ -62,22 +57,6 @@ public class TravelCourseControllerTest {
                         new PlaceDetailRequest("Place1", 37.7749, -122.4194),
                         new PlaceDetailRequest("Place2", 12.7749, -122.4194),
                         new PlaceDetailRequest("Place3", 16.7749, -122.4194))
-        );
-
-        places1 = List.of(place1, place2, place3);
-
-        placeRequests = List.of(placeRequest1);
-
-        validRequest = new TravelCourseRequest(
-                "나만의 코스",
-                2,
-                placeRequests
-        );
-
-        invalidRequest = new TravelCourseRequest(
-                null,
-                2,
-                null
         );
 
         travelCourse = new TravelCourse(
@@ -149,15 +128,16 @@ public class TravelCourseControllerTest {
         );
 
         List<TravelCourseListResponse> courseList = List.of(TravelCourseListResponse.toResponseListDto(travelCourse1), TravelCourseListResponse.toResponseListDto(travelCourse2));
+        TravelCourses travelCourses = new TravelCourses(courseList);
 
         // when
-        when(travelCourseService.findYoutuberTravelCourseByCreatorType()).thenReturn(courseList);
+        when(travelCourseService.findYoutuberTravelCourseByCreatorType()).thenReturn(travelCourses);
 
         // then
         mockMvc.perform(get("/api/travel-courses/youtubers")
                 .contentType("application/json"))
-                .andExpect(jsonPath("$.body.data[0].creatorType").value("YOUTUBER"))
-                .andExpect(jsonPath("$.body.data[0].creatorName").value("테스트TV"))
+                .andExpect(jsonPath("$.body.data.travelCourses[0].creatorType").value("YOUTUBER"))
+                .andExpect(jsonPath("$.body.data.travelCourses[0].creatorName").value("테스트TV"))
                 .andDo(print());
     }
 


### PR DESCRIPTION
## 개요

- ElastiCache를 도입해 데이터를 캐싱하여 기존 API를 더 빠르게 조회하고자 함.

### PR 타입

- 기능 추가
- 환경 변수 설정

### 반영 브랜치

- perf/50-elasticache-redis-lettuce -> main

## 변경 사항

- spring-data-redis모듈 추가
- h2 데이터베이스 사용을 mysql로 변경
- redis, lettuce 환경 변수 설정
- 빈번하게 조회가 이루어지는 /api/youtubers 및 /api/youtubers/{id} 를 캐싱에 적용
- List<> 형태의 json 역+직렬화 문제로 인한 Wrapper 객체 구현

### 테스트 결과

- [X] 로컬 환경에서 정상적으로 데이터가 캐싱되는 것을 확인
- [X] 배포 환경에서 정상적으로 redis 로 캐싱되는 것을 확인